### PR TITLE
Allow to define some app engine configs via ENV VAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ gem 'rails-cloud-tasks'
 require 'rails-cloud-tasks'
 
 RailsCloudTasks.configure do |config|
+  config.service_account_email = 'test-account@test-project.iam.gserviceaccount.com'
   config.project_id = 'my-gcp-project' # This is not needed if running on GCE
   config.location_id = 'us-central1'
 
@@ -47,6 +48,8 @@ RailsCloudTasks.configure do |config|
   config.inject_routes
 end
 ```
+
+You can use env-var to define _project_id_, _location_id_ and _service_account_email_ instead. Just add the following environment variables on your application: _GCP_LOCATION_, _GCP_PROJECT_, _GCP_SERVICE_ACCOUNT_.  The attributes will be fetched using GCP metadata if missing.
 
 - Add a Job class:
 ```ruby

--- a/lib/rails_cloud_tasks/configuration.rb
+++ b/lib/rails_cloud_tasks/configuration.rb
@@ -42,10 +42,6 @@ module RailsCloudTasks
           service_account_email: email
         }
       }
-    rescue RuntimeError, Errno::EHOSTDOWN
-      # EHOSTDOWN occurs sporadically when trying to resolve the metadata endpoint
-      # locally. It is unlikely to occur when running on GCE.
-      {}
     end
   end
 end

--- a/lib/rails_cloud_tasks/configuration.rb
+++ b/lib/rails_cloud_tasks/configuration.rb
@@ -3,14 +3,15 @@ module RailsCloudTasks
     attr_accessor :location_id, :host, :tasks_path, :service_account_email
 
     attr_writer :project_id
-    attr_reader :app_engine
+    attr_reader :app_engine, :google_auth
 
-    def initialize(app_engine = AppEngine)
+    def initialize(app_engine = AppEngine, google_auth = Google::Auth)
       @service_account_email = ENV['GCP_SERVICE_ACCOUNT']
       @location_id = ENV['GCP_LOCATION']
       @project_id = ENV['GCP_PROJECT']
       @tasks_path = '/tasks'
       @app_engine = app_engine
+      @google_auth = google_auth
     end
 
     def inject_routes
@@ -35,7 +36,7 @@ module RailsCloudTasks
     def authenticate
       email = service_account_email ||
               app_engine.service_account_email ||
-              Google::Auth.get_application_default.issuer
+              google_auth.get_application_default.issuer
 
       {
         oidc_token: {

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -4,3 +4,6 @@ require:
 
 Metrics/BlockLength:
   Max: 80
+
+RSpec/MultipleMemoizedHelpers:
+  AllowSubject: true

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 Metrics/BlockLength:
-  Max: 80
+  Max: 200
 
 RSpec/MultipleMemoizedHelpers:
   AllowSubject: true

--- a/spec/rails_cloud_tasks/app_engine_spec.rb
+++ b/spec/rails_cloud_tasks/app_engine_spec.rb
@@ -4,10 +4,10 @@ require 'google/cloud/tasks/v2'
 describe RailsCloudTasks::AppEngine do
   subject(:app_engine) { described_class }
 
+  before { app_engine.reset! }
+
   describe 'project_id' do
     subject(:project_id) { app_engine.project_id }
-
-    before { app_engine.reset! }
 
     context 'when not on GCE' do
       before do
@@ -31,8 +31,6 @@ describe RailsCloudTasks::AppEngine do
 
   describe 'service_account_email' do
     subject(:service_account_email) { app_engine.service_account_email }
-
-    before { app_engine.reset! }
 
     context 'when not on GCE' do
       before do

--- a/spec/rails_cloud_tasks/configuration_spec.rb
+++ b/spec/rails_cloud_tasks/configuration_spec.rb
@@ -1,0 +1,32 @@
+describe RailsCloudTasks::Configuration do
+  subject(:configuration) { described_class }
+
+  describe '#new' do
+    subject(:configuration_new) { configuration.new(app_engine) }
+
+    let(:app_engine) { class_spy(RailsCloudTasks::AppEngine) }
+    let(:service_account_email) { 'email@sample.com' }
+
+    its(:service_account_email) { is_expected.to be_nil }
+    its(:location_id) { is_expected.to be_nil }
+    its(:tasks_path) { is_expected.to eql('/tasks') }
+
+    context 'when config is set by ENVs' do
+      let(:stubs) do
+        {
+          'GCP_LOCATION' => 'env-location',
+          'GCP_SERVICE_ACCOUNT' => 'env-email@sample.com',
+          'GCP_PROJECT' => 'env-project-test'
+        }
+      end
+
+      before do
+        stub_const('ENV', ENV.to_hash.merge(stubs))
+      end
+
+      its(:location_id) { is_expected.to eql(stubs['GCP_LOCATION']) }
+      its(:project_id) { is_expected.to eql(stubs['GCP_PROJECT']) }
+      its(:service_account_email) { is_expected.to eql(stubs['GCP_SERVICE_ACCOUNT']) }
+    end
+  end
+end

--- a/spec/rails_cloud_tasks/configuration_spec.rb
+++ b/spec/rails_cloud_tasks/configuration_spec.rb
@@ -1,10 +1,11 @@
+# rubocop:disable Metrics/BlockLength
 describe RailsCloudTasks::Configuration do
-  subject(:configuration) { described_class }
+  subject(:configuration) { described_class.new(app_engine, google_auth) }
+
+  let(:app_engine) { class_spy(RailsCloudTasks::AppEngine) }
+  let(:google_auth) { class_spy(Google::Auth) }
 
   describe '#new' do
-    subject(:configuration_new) { configuration.new(app_engine) }
-
-    let(:app_engine) { class_spy(RailsCloudTasks::AppEngine) }
     let(:service_account_email) { 'email@sample.com' }
 
     its(:service_account_email) { is_expected.to be_nil }
@@ -29,4 +30,113 @@ describe RailsCloudTasks::Configuration do
       its(:service_account_email) { is_expected.to eql(stubs['GCP_SERVICE_ACCOUNT']) }
     end
   end
+
+  describe '#auth' do
+    subject(:call_auth) { configuration.auth }
+
+    let(:expected_auth) do
+      {
+        oidc_token: {
+          service_account_email: service_account_email
+        }
+      }
+    end
+
+    context 'when service account email is set on class init' do
+      let(:service_account_email) { 'email-test@iam.google' }
+
+      before do
+        stub_const('ENV', ENV.to_hash.merge('GCP_SERVICE_ACCOUNT' => service_account_email))
+      end
+
+      it { is_expected.to eql(expected_auth) }
+
+      it do
+        call_auth
+        expect(app_engine).not_to have_received(:service_account_email)
+      end
+
+      it do
+        call_auth
+        expect(google_auth).not_to have_received(:get_application_default)
+      end
+    end
+
+    context 'when service account email get from app engine' do
+      let(:service_account_email) { 'engine-email-test@iam.google' }
+
+      before do
+        allow(app_engine).to receive(:service_account_email).and_return(service_account_email)
+      end
+
+      it { is_expected.to eql(expected_auth) }
+
+      it do
+        call_auth
+        expect(app_engine).to have_received(:service_account_email)
+      end
+
+      it do
+        call_auth
+        expect(google_auth).not_to have_received(:get_application_default)
+      end
+    end
+
+    context 'when service account email get from google auth' do
+      let(:service_account_email) { 'google-auth-email-test@iam.google' }
+      let(:metadata) { OpenStruct.new(issuer: service_account_email) }
+
+      before do
+        allow(app_engine).to receive(:service_account_email).and_return(nil)
+        allow(google_auth).to receive(:get_application_default).and_return(metadata)
+      end
+
+      it { is_expected.to eql(expected_auth) }
+
+      it do
+        call_auth
+        expect(app_engine).to have_received(:service_account_email)
+      end
+
+      it do
+        call_auth
+        expect(google_auth).to have_received(:get_application_default)
+      end
+    end
+  end
+
+  describe '#project_id' do
+    subject(:call_project_id) { configuration.project_id }
+
+    context 'when the project_id is set' do
+      let(:project_id) { 'conf-test' }
+
+      before do
+        configuration.project_id = project_id
+      end
+
+      it { is_expected.to eq(project_id) }
+
+      it do
+        call_project_id
+        expect(app_engine).not_to have_received(:project_id)
+      end
+    end
+
+    context 'when the project_id get from app_engine set' do
+      let(:project_id) { 'app-engine-conf-test' }
+
+      before do
+        allow(app_engine).to receive(:project_id).and_return(project_id)
+      end
+
+      it { is_expected.to eq(project_id) }
+
+      it do
+        call_project_id
+        expect(app_engine).to have_received(:project_id)
+      end
+    end
+  end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/rails_cloud_tasks/configuration_spec.rb
+++ b/spec/rails_cloud_tasks/configuration_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 describe RailsCloudTasks::Configuration do
   subject(:configuration) { described_class.new(app_engine, google_auth) }
 
@@ -139,4 +138,3 @@ describe RailsCloudTasks::Configuration do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,4 +35,5 @@ RailsCloudTasks.configure do |config|
   config.location_id = 'us-central1'
   config.host = 'https://test.com'
   config.tasks_path = '/test-tasks'
+  config.service_account_email = 'test@email.eduk'
 end


### PR DESCRIPTION
We're defining the following attributes project_id, location_id and service_account_email via ENV-VAR also well. If missing the attributes will be fetched using GCP metadata