### PR TITLE
Force job serializer be encoded as ASCII-8BIT

### DIFF
--- a/lib/rails_cloud_tasks/adapter.rb
+++ b/lib/rails_cloud_tasks/adapter.rb
@@ -39,7 +39,7 @@ module RailsCloudTasks
         http_request:  {
           http_method: :POST,
           url:         url,
-          body:        { job: job.serialize }.to_json
+          body:        { job: job.serialize }.to_json.force_encoding('ASCII-8BIT')
         }.merge(auth),
         schedule_time: timestamp && Google::Protobuf::Timestamp.new.tap do |ts|
           ts.seconds = timestamp


### PR DESCRIPTION
It is required to avoid Google Cloud Tasks raise an error when the job arguments has any UTF-8 char