### PR TITLE
Change the scheduled job name delimiter to `--` instead of `__`

### DIFF
--- a/lib/rails_cloud_tasks/scheduler.rb
+++ b/lib/rails_cloud_tasks/scheduler.rb
@@ -40,7 +40,7 @@ module RailsCloudTasks
 
     def build_job(job)
       {
-        name:        "#{location_path}/jobs/#{scheduler_prefix_name}__#{job[:name]}",
+        name:        "#{location_path}/jobs/#{scheduler_prefix_name}--#{job[:name]}",
         schedule:    job[:schedule],
         description: job[:description],
         time_zone:   job[:time_zone],

--- a/spec/rails_cloud_tasks/scheduler_spec.rb
+++ b/spec/rails_cloud_tasks/scheduler_spec.rb
@@ -56,7 +56,7 @@ describe RailsCloudTasks::Scheduler do
     end
     let(:job2) do
       {
-        name:        "#{location_path}/jobs/testing-rails-cloud__MultArgsJob",
+        name:        "#{location_path}/jobs/testing-rails-cloud--MultArgsJob",
         schedule:    '0 8 * * *',
         description: 'Mult args',
         time_zone:   'America/Los_Angeles',


### PR DESCRIPTION
We've decided to change this delimiter because Google Task does not accept. Thus we changed the delimiter contract to use the same with `Tasks`, `Scheduler` and `Pub/Sub`