### PR TITLE
Do not omit errors on `/tasks`

### DIFF
--- a/lib/rails_cloud_tasks/rack/jobs.rb
+++ b/lib/rails_cloud_tasks/rack/jobs.rb
@@ -20,8 +20,6 @@ module RailsCloudTasks
           response(200, {})
         rescue Rack::InvalidPayloadError => e
           response(422, { error: e.message })
-        rescue StandardError => e
-          response(500, { error: e.message })
         end
 
         private

--- a/lib/rails_cloud_tasks/rack/tasks.rb
+++ b/lib/rails_cloud_tasks/rack/tasks.rb
@@ -17,8 +17,6 @@ module RailsCloudTasks
           response(200, {})
         rescue Rack::InvalidPayloadError => e
           response(400, { error: e.cause.message })
-        rescue StandardError => e
-          response(500, { error: e.message })
         end
 
         private

--- a/spec/rails_cloud_tasks/rack/jobs_spec.rb
+++ b/spec/rails_cloud_tasks/rack/jobs_spec.rb
@@ -49,9 +49,9 @@ describe RailsCloudTasks::Rack::Jobs do
         allow(DummyJob).to receive(:perform_now).and_raise(StandardError, 'some error')
       end
 
-      its(:first)  { is_expected.to eq 500 }
-      its(:second) { is_expected.to eq('Content-Type' => 'application/json') }
-      its(:third)  { is_expected.to eq [{ error: 'some error' }.to_json] }
+      it do
+        expect { call }.to raise_error(StandardError)
+      end
     end
   end
 end

--- a/spec/rails_cloud_tasks/rack/tasks_spec.rb
+++ b/spec/rails_cloud_tasks/rack/tasks_spec.rb
@@ -54,9 +54,9 @@ describe RailsCloudTasks::Rack::Tasks do
         allow(ActiveJob::Base).to receive(:execute).and_raise(StandardError, 'some error')
       end
 
-      its(:first)  { is_expected.to eq 500 }
-      its(:second) { is_expected.to eq('Content-Type' => 'application/json') }
-      its(:third)  { is_expected.to eq [{ error: 'some error' }.to_json] }
+      it do
+        expect { call }.to raise_error(StandardError)
+      end
     end
   end
 end


### PR DESCRIPTION
The exceptions (StandardError subclasses) raised on /tasks were not capture by error tracker