### PR TITLE
Loading Google Client lazy

### DIFF
--- a/lib/rails_cloud_tasks/adapter.rb
+++ b/lib/rails_cloud_tasks/adapter.rb
@@ -2,13 +2,7 @@ require 'google-cloud-tasks'
 
 module RailsCloudTasks
   class Adapter
-    attr_reader :client
-
     delegate :project_id, :location_id, :host, :tasks_path, :auth, to: 'RailsCloudTasks.config'
-
-    def initialize(client = Google::Cloud::Tasks.cloud_tasks)
-      @client = client
-    end
 
     def enqueue(job, timestamp = nil)
       path = client.queue_path(project: project_id, location: location_id, queue: job.queue_name)
@@ -26,6 +20,10 @@ module RailsCloudTasks
 
     def enqueue_at(job, timestamp)
       enqueue(job, timestamp.to_i)
+    end
+
+    def client
+      @client ||= Google::Cloud::Tasks.cloud_tasks
     end
 
     private

--- a/lib/rails_cloud_tasks/scheduler.rb
+++ b/lib/rails_cloud_tasks/scheduler.rb
@@ -4,17 +4,13 @@ module RailsCloudTasks
              :scheduler_file_path, :scheduler_prefix_name,
              :service_account_email, to: 'RailsCloudTasks.config'
 
-    attr_reader :client, :credentials, :logger
+    attr_reader :credentials, :logger
 
     def initialize(
-      client: Google::Cloud::Scheduler.cloud_scheduler,
       credentials: RailsCloudTasks::Credentials.new,
       logger: RailsCloudTasks.logger
     )
-      client.configure do |config|
-        config.credentials = credentials.generate(service_account_email)
-      end
-      @client = client
+      @credentials = credentials
       @logger = logger
     end
 
@@ -26,6 +22,12 @@ module RailsCloudTasks
         upsert_job(job) ? (result[:success] << job[:name]) : (result[:failure] << job[:name])
       end
       log_output(result)
+    end
+
+    def client
+      @client ||= Google::Cloud::Scheduler.cloud_scheduler.configure do |config|
+        config.credentials = credentials.generate(service_account_email)
+      end
     end
 
     protected

--- a/lib/rails_cloud_tasks/version.rb
+++ b/lib/rails_cloud_tasks/version.rb
@@ -1,3 +1,3 @@
 module RailsCloudTasks
-  VERSION = '0.0.6'.freeze
+  VERSION = '0.0.7'.freeze
 end

--- a/spec/rails_cloud_tasks/adapter_spec.rb
+++ b/spec/rails_cloud_tasks/adapter_spec.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext'
 require 'google/cloud/tasks/v2'
 
 describe RailsCloudTasks::Adapter do
-  subject(:instance) { described_class.new(client) }
+  subject(:instance) { described_class.new }
 
   let(:job) { DummyJob.new(args) }
   let(:args) { { arg1: 'one', arg2: 'two', text: 'By forcing encode âã' } }
@@ -10,6 +10,10 @@ describe RailsCloudTasks::Adapter do
   let(:config) { RailsCloudTasks.config }
 
   let(:client) { instance_spy(Google::Cloud::Tasks::V2::CloudTasks::Client) }
+
+  before do
+    allow(Google::Cloud::Tasks).to receive(:cloud_tasks).and_return(client)
+  end
 
   describe 'enqueue' do
     subject(:enqueue) { instance.enqueue(job, tomorrow) }

--- a/spec/rails_cloud_tasks/scheduler_spec.rb
+++ b/spec/rails_cloud_tasks/scheduler_spec.rb
@@ -1,7 +1,7 @@
 describe RailsCloudTasks::Scheduler do
   require 'google/cloud/scheduler/v1'
   subject(:scheduler) do
-    described_class.new(client: client, credentials: credentials, logger: logger)
+    described_class.new(credentials: credentials, logger: logger)
   end
 
   let(:client) { instance_spy(Google::Cloud::Scheduler::V1::CloudScheduler::Client) }
@@ -10,7 +10,13 @@ describe RailsCloudTasks::Scheduler do
   let(:config) { RailsCloudTasks.config }
   let(:service_account_email) { config.service_account_email }
 
+  before do
+    allow(Google::Cloud::Scheduler).to receive(:cloud_scheduler).and_return(client)
+  end
+
   context 'with credentials' do
+    subject(:client_call) { scheduler.client }
+
     let(:configuration) do
       instance_spy(Google::Cloud::Scheduler::V1::CloudScheduler::Client::Configuration)
     end
@@ -22,12 +28,12 @@ describe RailsCloudTasks::Scheduler do
     end
 
     it do
-      scheduler
+      client_call
       expect(credentials).to have_received(:generate).with(service_account_email)
     end
 
     it do
-      scheduler
+      client_call
       expect(configuration).to have_received(:credentials=).with(fake_credential)
     end
   end

--- a/spec/rails_cloud_tasks/version_spec.rb
+++ b/spec/rails_cloud_tasks/version_spec.rb
@@ -1,3 +1,3 @@
 describe RailsCloudTasks::VERSION do
-  it { is_expected.to eq '0.0.6' }
+  it { is_expected.to eq '0.0.7' }
 end


### PR DESCRIPTION
The Google Clients were loaded on class booting, it's a big issue while booting app and other Rail's simple operations, such as assets:precompile. Because the Google Client makes gRPC requests to build its client with credentials.

This change will speed the app booting uptime and avoid unnecessary requests to build any Google Client